### PR TITLE
Fix self hosting instance docker-compose

### DIFF
--- a/docker-compose.nitter.yml
+++ b/docker-compose.nitter.yml
@@ -7,7 +7,7 @@ services:
     image: ghcr.io/sekai-soft/nitter-self-contained
     container_name: nitter
     ports:
-      - "0.0.0.0:8080:8081"
+      - "0.0.0.0:8080:8080"
     volumes:
       - nitter-data:/nitter-data
     depends_on:
@@ -21,7 +21,7 @@ services:
       - .env
     restart: unless-stopped
     healthcheck:
-      test: wget -nv --tries=1 --spider http://127.0.0.1:80 || exit 1
+      test: wget -nv --tries=1 --spider http://127.0.0.1:8080 || exit 1
       interval: 5s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
I tried following your instructions on the [readme](https://github.com/sekai-soft/guide-nitter-self-hosting/blob/master/docs/i-only-want-a-nitter-instance.md), it doesn't seem to work when I did a `curl localhost:8080`. Figured out that it's due to the ports being incorrect.

Also I don't think `cp nitter.example.conf nitter.conf` in your [docs/i-only-want-a-nitter-instance.md](https://github.com/sekai-soft/guide-nitter-self-hosting/blob/master/docs/i-only-want-a-nitter-instance.md) instruction do anything because the file is already in your docker image. 